### PR TITLE
fix: make Buffer extend Object directly

### DIFF
--- a/include/napi-inl.h
+++ b/include/napi-inl.h
@@ -2834,20 +2834,26 @@ inline void ArrayBuffer::Detach() {
     }
 
     template <typename T>
-    inline Buffer<T>::Buffer() : Uint8Array() {}
+    inline Buffer<T>::Buffer() : Object() {}
 
     template <typename T>
     inline Buffer<T>::Buffer(napi_env env, napi_value value)
-            : Uint8Array(env, value) {}
+            : Object(env, value) {}
 
     template <typename T>
     inline size_t Buffer<T>::Length() const {
-        return ByteLength() / sizeof(T);
+        void *data = nullptr;
+        size_t length = 0;
+        napi_get_buffer_info(_env, _value, &data, &length);
+        return length;
     }
 
     template <typename T>
     inline T* Buffer<T>::Data() const {
-        return reinterpret_cast<T*>(const_cast<uint8_t*>(Uint8Array::Data()));
+        void *data = nullptr;
+        size_t length = 0;
+        napi_get_buffer_info(_env, _value, &data, &length);
+        return reinterpret_cast<T*>(data);
     }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/include/napi.h
+++ b/include/napi.h
@@ -1516,7 +1516,7 @@ class Date : public Value {
     };
 
     template <typename T>
-    class Buffer : public Uint8Array {
+    class Buffer : public Object {
     public:
         static Buffer<T> New(napi_env env, size_t length);
 #ifndef NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED


### PR DESCRIPTION
鸿蒙的Buffer不继承自Uint8Array, 所以对Buffer对象调用napi_get_typedarray_info会返回napi_invalid_arg异常
详见 https://gitee.com/openharmony/arkui_napi/blob/master/native_engine/native_api.cpp#L2738