### PR TITLE
fix: failed to get ArrayBuffer data and size

### DIFF
--- a/include/napi-inl.h
+++ b/include/napi-inl.h
@@ -2166,15 +2166,16 @@ inline ArrayBuffer::ArrayBuffer(napi_env env, napi_value value)
 
 inline void* ArrayBuffer::Data() {
   void* data;
-  napi_status status = napi_get_arraybuffer_info(_env, _value, &data, nullptr);
+  size_t length;
+  napi_status status = napi_get_arraybuffer_info(_env, _value, &data, &length);
   NAPI_THROW_IF_FAILED(_env, status, nullptr);
   return data;
 }
 
 inline size_t ArrayBuffer::ByteLength() {
+  void* data;
   size_t length;
-  napi_status status =
-      napi_get_arraybuffer_info(_env, _value, nullptr, &length);
+  napi_status status = napi_get_arraybuffer_info(_env, _value, &data, &length);
   NAPI_THROW_IF_FAILED(_env, status, 0);
   return length;
 }


### PR DESCRIPTION
napi_get_arraybuffer_info需要同时传入data和byte_length，见https://gitcode.com/openharmony/arkui_napi/blob/master/native_engine/native_api.cpp#L2869

```cpp
NAPI_EXTERN napi_status napi_get_arraybuffer_info(napi_env env,
                                                  napi_value arraybuffer,
                                                  void** data,
                                                  size_t* byte_length)
{
    CHECK_ENV(env);
    CHECK_ARG(env, arraybuffer);
    CHECK_ARG(env, byte_length); // <-- 调用时必须传入byte_length, 否则返回napi_invalid_arg错误

    auto nativeValue = LocalValueFromJsValue(arraybuffer);
    auto vm = reinterpret_cast<NativeEngine*>(env)->GetEcmaVm();
    panda::JsiFastNativeScope fastNativeScope(vm);
    if (LIKELY(nativeValue->IsArrayBuffer(vm))) {
        Local<panda::ArrayBufferRef> res(nativeValue);
        int32_t length = 0;
        void *innerData = res->GetBufferAndLength(vm, &length);
        if (data != nullptr) {
            *data = innerData;
        }
        *byte_length = length;
    } else if (nativeValue->IsSendableArrayBuffer(vm)) {
        Local<panda::SendableArrayBufferRef> res(nativeValue);
        if (data != nullptr) {
            *data = res->GetBuffer(vm);
        }
        *byte_length = res->ByteLength(vm);
    } else {
        return napi_set_last_error(env, napi_arraybuffer_expected);
    }

    return napi_clear_last_error(env);
}
```